### PR TITLE
Fixed Initial User Search Function.

### DIFF
--- a/BlazorApp/Components/Pages/ProfileSearch.razor
+++ b/BlazorApp/Components/Pages/ProfileSearch.razor
@@ -21,32 +21,43 @@
 </div>
 
 @code {
-    private List<UserProfiles> foundUsers = new List<UserProfiles>();
+    private string inputSearch = "";
+    private List<UserClasses.UserProfiles> allUsers = new List<UserClasses.UserProfiles>();
+    private List<UserClasses.UserProfiles> searchedUsers = new List<UserClasses.UserProfiles>();
 
-private string connectionString = "Host=ep-purple-star-a20n8auz.eu-central-1.aws.neon.tech;Port=5432;Username=techvendo69;Password=qVyZgOJ36HtK;Database=TechVendo;SslMode=Require;";
-private NpgsqlConnection connection;
 
- protected override void OnInitialized()
- {
-     base.OnInitialized();
-     connection = new NpgsqlConnection(connectionString);
-     connection.Open();
-}
+    private string connectionString = "Host=ep-purple-star-a20n8auz.eu-central-1.aws.neon.tech;Port=5432;Username=techvendo69;Password=qVyZgOJ36HtK;Database=TechVendo;SslMode=Require;";
+    private NpgsqlConnection connection;
 
-  string SelectSQL = $"SELECT * FROM userprofiles WHERE firstname LIKE %{firstnameVariable}% ";
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+        connection = new NpgsqlConnection(connectionString);
+        connection.Open();
+    }
+    private void GetUsers()
+    {
+        string SelectSQL = $"SELECT * FROM userprofiles WHERE firstname LIKE '%{inputSearch}%'";
 
-  using (NpgsqlCommand command = new NpgsqlCommand(SelectSQL, connection))
-  {
-      using (NpgsqlDataReader reader = command.ExecuteReader())
-      {
-          while (reader.Read())
-          {
-              UserClasses.UserProfiles user = new UserClasses.UserProfiles{
-
-              };
-          }
-      }
-  }
+        using (NpgsqlCommand command = new NpgsqlCommand(SelectSQL, connection))
+        {
+            using (NpgsqlDataReader reader = command.ExecuteReader())
+            {
+                while (reader.Read())
+                {
+                    UserClasses.UserProfiles user = new UserClasses.UserProfiles
+                        {
+                            FirstName = reader["firstname"].ToString(),
+                            LastName = reader["lastname"].ToString(),
+                            ProfileId = (int)reader["id"]
+                };
+                    allUsers.Add(user);
+                    searchedUsers.Add(user);
+                }
+            }
+        }
+    }
+   
 
 }
 


### PR DESCRIPTION
Alexander can work on the rest of the usersearch.

It should be made case-insensitive (made into issue on Sprint 3)

There is a list for all users that it finds to start with, to show MAX 20 users. (Find a way to max)

There is a list for searchedUsers, that currently has the same as all users. Delete this. (Line 55)

Searched Users should be filled only once the name has been 